### PR TITLE
black autoformat in merge to master CI

### DIFF
--- a/.github/workflows/ci_branch.yaml
+++ b/.github/workflows/ci_branch.yaml
@@ -20,9 +20,6 @@ jobs:
         run: |
           pip install clinner pip poetry --upgrade
           python make install
-      - id: black
-        name: Code format checking
-        run: python make black --check .
       - id: isort
         name: Imports order checking
         run: python make isort --check-only

--- a/.github/workflows/ci_master.yaml
+++ b/.github/workflows/ci_master.yaml
@@ -24,8 +24,8 @@ jobs:
           pip install clinner pip poetry --upgrade
           python make install
       - id: black
-        name: Code format checking
-        run: python make black --check .
+        name: Code formatting
+        run: python make black .
       - id: isort
         name: Imports order checking
         run: python make isort --check-only


### PR DESCRIPTION
The idea here is to do linting only with `flake8` during development on a branch, but then actually reformat the code with `black` upon merging to master (along with `flake8` linting).

This allows flexibility for contributors while maintaining a uniform code style. 

